### PR TITLE
Make all indexers track errors

### DIFF
--- a/src/characters/commands.ts
+++ b/src/characters/commands.ts
@@ -6,6 +6,10 @@ import { firstUppercase } from "utils/strings";
 import { CustomSuggestModal } from "utils/suggest";
 import { PromptModal } from "utils/ui/prompt";
 import {
+  NoCharacterActionConext as NoCharacterActionContext,
+  determineCharacterActionContext,
+} from "./action-context";
+import {
   addAsset,
   defaultMarkedAbilitiesForAsset,
   getPathLabel,
@@ -18,7 +22,14 @@ export async function addAssetToCharacter(
   _editor: Editor,
   _view: MarkdownView,
 ): Promise<void> {
-  const [path, context] = plugin.characters.activeCharacter();
+  const actionContext = await determineCharacterActionContext(plugin);
+  // TODO: maybe we could make this part of the checkCallback? (i.e., if we are in no character
+  // mode, don't even bother to list this command?)
+  if (!actionContext || actionContext instanceof NoCharacterActionContext) {
+    return;
+  }
+  const path = actionContext.characterPath;
+  const context = actionContext.characterContext;
   const { character, lens } = context;
   const characterAssets = lens.assets.get(character);
 

--- a/src/characters/meter-commands.ts
+++ b/src/characters/meter-commands.ts
@@ -11,6 +11,7 @@ import {
   ActionContext,
   CharacterActionContext,
   determineCharacterActionContext,
+  requireActiveCharacterContext,
 } from "./action-context";
 import { MeterWithLens, MeterWithoutLens, momentumOps } from "./lens";
 
@@ -18,7 +19,11 @@ export async function burnMomentum(
   plugin: IronVaultPlugin,
   editor: Editor,
 ): Promise<void> {
-  const [path, charContext] = plugin.characters.activeCharacter();
+  const actionContext = await requireActiveCharacterContext(plugin);
+  const [path, charContext] = [
+    actionContext.characterPath,
+    actionContext.characterContext,
+  ];
   const { lens, character } = charContext;
   const oldValue = lens.momentum.get(character);
   if (oldValue > 0) {

--- a/src/indexer/index-impl.ts
+++ b/src/indexer/index-impl.ts
@@ -1,0 +1,79 @@
+import { Either } from "utils/either";
+
+function filteredReadonlyMap<K, V, U>(
+  select: (val: V) => U | undefined,
+): new (baseMap: Map<K, V>) => ReadonlyMap<K, U> {
+  return class FilteredReadonlyMap implements ReadonlyMap<K, U> {
+    #innerMap: ReadonlyMap<K, V>;
+    constructor(innerMap: ReadonlyMap<K, V>) {
+      this.#innerMap = innerMap;
+    }
+    forEach(
+      callbackfn: (value: U, key: K, map: ReadonlyMap<K, U>) => void,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      thisArg?: any,
+    ): void {
+      this.#innerMap.forEach((v, key) => {
+        const selected = select(v);
+        if (selected) {
+          callbackfn.bind(thisArg)(selected, key, this);
+        }
+      }, thisArg);
+    }
+
+    get(key: K): U | undefined {
+      const val = this.#innerMap.get(key);
+      return val && select(val);
+    }
+
+    has(key: K): boolean {
+      if (!this.#innerMap.has(key)) return false;
+      const val = this.#innerMap.get(key);
+      return !!select(val!);
+    }
+
+    get size(): number {
+      let count: number = 0;
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      for (const _key of this.keys()) {
+        count++;
+      }
+      return count;
+    }
+    entries(): IterableIterator<[K, U]> {
+      return this[Symbol.iterator]();
+    }
+    *keys(): IterableIterator<K> {
+      for (const entry of this.#innerMap) {
+        yield entry[0];
+      }
+    }
+    *values(): IterableIterator<U> {
+      for (const entry of this) {
+        yield entry[1];
+      }
+    }
+    *[Symbol.iterator](): IterableIterator<[K, U]> {
+      for (const [key, value] of this.#innerMap) {
+        const selected = select(value);
+        if (selected) {
+          yield [key, selected];
+        }
+      }
+    }
+  };
+}
+
+export function resultFilteredMapClass<K, T, E extends Error>() {
+  return filteredReadonlyMap<K, Either<E, T>, T>((result) =>
+    result.isRight() ? result.value : undefined,
+  );
+}
+
+export class Index<T, E extends Error> extends Map<string, Either<E, T>> {
+  readonly ofValid: ReadonlyMap<string, T> = new (resultFilteredMapClass<
+    string,
+    T,
+    E
+  >())(this);
+}

--- a/src/moves/action/index.ts
+++ b/src/moves/action/index.ts
@@ -230,7 +230,7 @@ export async function runMoveCommand(
     case "progress_roll": {
       moveDescription = await handleProgressRoll(
         plugin.app,
-        new ProgressContext(plugin),
+        new ProgressContext(plugin, context),
         move,
       );
       break;

--- a/src/tracks/clock-file.ts
+++ b/src/tracks/clock-file.ts
@@ -1,8 +1,9 @@
 import { produce } from "immer";
+import { Index } from "indexer/index-impl";
 import { CachedMetadata } from "obsidian";
 import { normalizeKeys } from "utils/zodutils";
 import { z } from "zod";
-import { BaseIndexer } from "../indexer/indexer";
+import { BaseIndexer, IndexUpdate } from "../indexer/indexer";
 import { Either, Left } from "../utils/either";
 import { updater } from "../utils/update";
 import { Clock } from "./clock";
@@ -83,15 +84,14 @@ export class ClockFileAdapter {
   }
 }
 
-export class ClockIndexer extends BaseIndexer<ClockFileAdapter> {
+export class ClockIndexer extends BaseIndexer<ClockFileAdapter, z.ZodError> {
   readonly id: string = "clock";
 
   processFile(
     path: string,
     cache: CachedMetadata,
-  ): ClockFileAdapter | undefined {
-    // TODO: we should use our Either support now to handle this
-    return ClockFileAdapter.create(cache.frontmatter).unwrap();
+  ): IndexUpdate<ClockFileAdapter, z.ZodError> {
+    return ClockFileAdapter.create(cache.frontmatter);
   }
 }
 
@@ -102,4 +102,4 @@ export const clockUpdater = updater<ClockFileAdapter>(
   (tracker) => tracker.raw,
 );
 
-export type ClockIndex = Map<string, ClockFileAdapter>;
+export type ClockIndex = Index<ClockFileAdapter, z.ZodError>;

--- a/src/tracks/progress.ts
+++ b/src/tracks/progress.ts
@@ -2,7 +2,7 @@ import { produce } from "immer";
 import { CachedMetadata } from "obsidian";
 import { normalizeKeys } from "utils/zodutils";
 import { ZodError, z } from "zod";
-import { BaseIndexer } from "../indexer/indexer";
+import { BaseIndexer, IndexOf, IndexUpdate } from "../indexer/indexer";
 import { Either, Left, Right } from "../utils/either";
 
 export enum ChallengeRanks {
@@ -287,20 +287,18 @@ export class ProgressTrackFileAdapter implements ProgressTrackInfo {
   }
 }
 
-export class ProgressIndexer extends BaseIndexer<ProgressTrackFileAdapter> {
+export class ProgressIndexer extends BaseIndexer<
+  ProgressTrackFileAdapter,
+  z.ZodError
+> {
   readonly id: string = "progress";
-
-  constructor(index: ProgressIndex) {
-    super(index);
-  }
 
   processFile(
     path: string,
     cache: CachedMetadata,
-  ): ProgressTrackFileAdapter | undefined {
-    // TODO: we should use our Either support now to handle this
-    return ProgressTrackFileAdapter.create(cache.frontmatter).unwrap();
+  ): IndexUpdate<ProgressTrackFileAdapter, z.ZodError> {
+    return ProgressTrackFileAdapter.create(cache.frontmatter);
   }
 }
 
-export type ProgressIndex = Map<string, ProgressTrackFileAdapter>;
+export type ProgressIndex = IndexOf<ProgressIndexer>;

--- a/src/tracks/select-clock.ts
+++ b/src/tracks/select-clock.ts
@@ -8,7 +8,7 @@ export async function selectClock(
   app: App,
   filter?: (track: [string, ClockFileAdapter]) => boolean,
 ): Promise<[string, ClockFileAdapter]> {
-  let clocks = [...clockIndex.entries()];
+  let clocks = [...clockIndex.ofValid.entries()];
   if (filter) {
     clocks = clocks.filter(filter);
   }

--- a/src/utils/either.ts
+++ b/src/utils/either.ts
@@ -36,6 +36,10 @@ export class Left<T> {
   unwrap(): never {
     return this.expect("expected a value");
   }
+
+  unwrapError(): T {
+    return this.error;
+  }
 }
 export class Right<U> {
   private constructor(public readonly value: U) {}
@@ -66,6 +70,10 @@ export class Right<U> {
 
   unwrap(): U {
     return this.expect("expected a value");
+  }
+
+  unwrapError(): never {
+    throw new Error("expected an error, but found value");
   }
 }
 


### PR DESCRIPTION
Overhauls indexers to preserve errors.

As part of changing indexers, this replaces CharacterTracker with the same Index that Clocks and Tracks use. To abstract away that change, more code that used CharacterTracker directly now works through an ActionContext.

Fixes #81