### PR TITLE
Use index change events to re-render clock and track blocks

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -1,10 +1,10 @@
 import { syntaxTree } from "@codemirror/language";
 import { App } from "obsidian";
+import { ProgressIndex } from "tracks/indexer";
 import { CharacterTracker } from "./character-tracker";
 import { Datastore } from "./datastore";
 import IronVaultPlugin from "./index";
 import { RollWrapper } from "./model/rolls";
-import { ProgressIndex } from "./tracks/progress";
 
 function stripLinks(input: string): string {
   return input.replace(/\[([^\]]+)\]\([^)]+\)/g, "$1");

--- a/src/characters/commands.ts
+++ b/src/characters/commands.ts
@@ -3,7 +3,7 @@ import { produce } from "immer";
 import IronVaultPlugin from "index";
 import { Editor, FuzzyMatch, MarkdownView } from "obsidian";
 import { createNewIronVaultEntityFile, vaultProcess } from "utils/obsidian";
-import { firstUppercase } from "utils/strings";
+import { capitalize } from "utils/strings";
 import { CustomSuggestModal } from "utils/suggest";
 import { PromptModal } from "utils/ui/prompt";
 import { IronVaultKind, pluginPrefixed } from "../constants";
@@ -77,7 +77,7 @@ export async function addAssetToCharacter(
           Object.entries(optionField.choices),
           ([_choiceKey, choice]) => choice.label,
           undefined,
-          firstUppercase(optionField.label),
+          capitalize(optionField.label),
         );
         optionValues[key] = choice[0];
         break;
@@ -91,7 +91,7 @@ export async function addAssetToCharacter(
       case "text": {
         optionValues[key] = await PromptModal.prompt(
           plugin.app,
-          firstUppercase(optionField.label),
+          capitalize(optionField.label),
         );
       }
     }

--- a/src/clocks/clock-file.ts
+++ b/src/clocks/clock-file.ts
@@ -1,5 +1,5 @@
 import { produce } from "immer";
-import { Index } from "indexer/index-impl";
+import { Index } from "indexer";
 import { CachedMetadata } from "obsidian";
 import { normalizeKeys } from "utils/zodutils";
 import { z } from "zod";

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ import { IronVaultPluginSettings } from "settings";
 import registerSidebarBlocks from "sidebar/sidebar-block";
 import { SidebarView, VIEW_TYPE } from "sidebar/sidebar-view";
 import { ProgressContext } from "tracks/context";
+import { ProgressIndex, ProgressIndexer } from "tracks/indexer";
 import registerTrackBlock from "tracks/track-block";
 import { IronVaultAPI } from "./api";
 import { CharacterIndexer, CharacterTracker } from "./character-tracker";
@@ -33,7 +34,6 @@ import { runOracleCommand } from "./oracles/command";
 import { registerOracleBlock } from "./oracles/render";
 import { IronVaultSettingTab } from "./settings/ui";
 import { advanceProgressTrack, createProgressTrack } from "./tracks/commands";
-import { ProgressIndex, ProgressIndexer } from "./tracks/progress";
 import { pluginAsset } from "./utils/obsidian";
 
 export default class IronVaultPlugin extends Plugin {

--- a/src/indexer/index-interface.ts
+++ b/src/indexer/index-interface.ts
@@ -1,0 +1,21 @@
+import { EventRef } from "obsidian";
+import { Either } from "utils/either";
+
+export interface Index<T, E extends Error> extends Map<string, Either<E, T>> {
+  readonly ofValid: ReadonlyMap<string, T>;
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  on(name: "changed", callback: (path: string) => any, ctx?: any): EventRef;
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  on(name: string, callback: (...data: any) => any, ctx?: any): EventRef;
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  off(name: string, callback: (...data: any) => any): void;
+
+  offref(ref: EventRef): void;
+
+  trigger(name: "changed", path: string): void;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  trigger(name: string, ...data: any[]): void;
+}

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -1,0 +1,1 @@
+export { type Index } from "./index-interface";

--- a/src/indexer/indexer.ts
+++ b/src/indexer/indexer.ts
@@ -1,7 +1,8 @@
-import { Index } from "indexer/index-impl";
+import { Index } from "indexer/index-interface";
 import { type CachedMetadata } from "obsidian";
 import { Either, Left } from "utils/either";
 import { IronVaultKind } from "../constants";
+import { IndexImpl } from "./index-impl";
 
 export type IndexErrorResult<E extends Error> = { type: "error"; error: E };
 export type IndexUpdateResult<V, E extends Error> =
@@ -54,7 +55,7 @@ export type IndexOf<Idx> =
 
 export abstract class BaseIndexer<T, E extends Error> implements Indexer {
   abstract readonly id: IronVaultKind;
-  public readonly index: Index<T, E> = new Index();
+  public readonly index: Index<T, E> = new IndexImpl();
 
   constructor() {}
 

--- a/src/tracks/context.ts
+++ b/src/tracks/context.ts
@@ -5,7 +5,8 @@ import {
 import { App } from "obsidian";
 import IronVaultPlugin from "../index";
 import { vaultProcess } from "../utils/obsidian";
-import { ProgressIndex, ProgressTrackInfo } from "./progress";
+import { ProgressIndex } from "./indexer";
+import { ProgressTrackInfo } from "./progress";
 import {
   LegacyTrackWriter,
   ProgressTrackFileWriter,

--- a/src/tracks/indexer.ts
+++ b/src/tracks/indexer.ts
@@ -1,0 +1,21 @@
+import { CachedMetadata } from "obsidian";
+import { z } from "zod";
+import { IronVaultKind } from "../constants";
+import { BaseIndexer, IndexOf, IndexUpdate } from "../indexer/indexer";
+import { ProgressTrackFileAdapter } from "./progress";
+
+export class ProgressIndexer extends BaseIndexer<
+  ProgressTrackFileAdapter,
+  z.ZodError
+> {
+  readonly id = IronVaultKind.ProgressTrack;
+
+  processFile(
+    path: string,
+    cache: CachedMetadata,
+  ): IndexUpdate<ProgressTrackFileAdapter, z.ZodError> {
+    return ProgressTrackFileAdapter.create(cache.frontmatter);
+  }
+}
+
+export type ProgressIndex = IndexOf<ProgressIndexer>;

--- a/src/tracks/progress.ts
+++ b/src/tracks/progress.ts
@@ -1,9 +1,7 @@
 import { produce } from "immer";
-import { CachedMetadata } from "obsidian";
 import { normalizeKeys } from "utils/zodutils";
 import { ZodError, z } from "zod";
 import { IronVaultKind, PLUGIN_KIND_FIELD } from "../constants";
-import { BaseIndexer, IndexOf, IndexUpdate } from "../indexer/indexer";
 import { Either, Left, Right } from "../utils/either";
 
 export enum ChallengeRanks {
@@ -287,19 +285,3 @@ export class ProgressTrackFileAdapter implements ProgressTrackInfo {
     );
   }
 }
-
-export class ProgressIndexer extends BaseIndexer<
-  ProgressTrackFileAdapter,
-  z.ZodError
-> {
-  readonly id = IronVaultKind.ProgressTrack;
-
-  processFile(
-    path: string,
-    cache: CachedMetadata,
-  ): IndexUpdate<ProgressTrackFileAdapter, z.ZodError> {
-    return ProgressTrackFileAdapter.create(cache.frontmatter);
-  }
-}
-
-export type ProgressIndex = IndexOf<ProgressIndexer>;

--- a/src/tracks/track-block.ts
+++ b/src/tracks/track-block.ts
@@ -5,6 +5,7 @@ import IronVaultPlugin from "index";
 import { EventRef, TFile } from "obsidian";
 import { Left } from "utils/either";
 import { vaultProcess } from "utils/obsidian";
+import { capitalize } from "utils/strings";
 import { ProgressTrackFileAdapter, ProgressTrackInfo } from "./progress";
 import { progressTrackUpdater } from "./writer";
 
@@ -144,8 +145,4 @@ export function renderTrack(
     </article>
   `;
   return tpl;
-}
-
-function capitalize(s: string) {
-  return s.charAt(0).toUpperCase() + s.slice(1);
 }

--- a/src/utils/filename.ts
+++ b/src/utils/filename.ts
@@ -1,10 +1,10 @@
-import { firstUppercase } from "./strings";
+import { capitalize } from "./strings";
 
 const OBSIDIAN_ILLEGAL_FILENAME_CHARS = /[/\\:*?"<>|#^[\]]/g;
 
 /** Creates an Obsidian filename from a string. */
 export function generateObsidianFilename(name: string): string {
-  return firstUppercase(
+  return capitalize(
     name
       .replaceAll(OBSIDIAN_ILLEGAL_FILENAME_CHARS, " ")
       .replaceAll(/\s+/g, " ")

--- a/src/utils/filtered-map.ts
+++ b/src/utils/filtered-map.ts
@@ -1,0 +1,71 @@
+import { Either } from "utils/either";
+
+function filteredReadonlyMap<K, V, U>(
+  select: (val: V) => U | undefined,
+): new (baseMap: Map<K, V>) => ReadonlyMap<K, U> {
+  return class FilteredReadonlyMap implements ReadonlyMap<K, U> {
+    #innerMap: ReadonlyMap<K, V>;
+    constructor(innerMap: ReadonlyMap<K, V>) {
+      this.#innerMap = innerMap;
+    }
+    forEach(
+      callbackfn: (value: U, key: K, map: ReadonlyMap<K, U>) => void,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      thisArg?: any,
+    ): void {
+      this.#innerMap.forEach((v, key) => {
+        const selected = select(v);
+        if (selected) {
+          callbackfn.bind(thisArg)(selected, key, this);
+        }
+      }, thisArg);
+    }
+
+    get(key: K): U | undefined {
+      const val = this.#innerMap.get(key);
+      return val && select(val);
+    }
+
+    has(key: K): boolean {
+      if (!this.#innerMap.has(key)) return false;
+      const val = this.#innerMap.get(key);
+      return !!select(val!);
+    }
+
+    get size(): number {
+      let count: number = 0;
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      for (const _key of this.keys()) {
+        count++;
+      }
+      return count;
+    }
+    entries(): IterableIterator<[K, U]> {
+      return this[Symbol.iterator]();
+    }
+    *keys(): IterableIterator<K> {
+      for (const entry of this.#innerMap) {
+        yield entry[0];
+      }
+    }
+    *values(): IterableIterator<U> {
+      for (const entry of this) {
+        yield entry[1];
+      }
+    }
+    *[Symbol.iterator](): IterableIterator<[K, U]> {
+      for (const [key, value] of this.#innerMap) {
+        const selected = select(value);
+        if (selected) {
+          yield [key, selected];
+        }
+      }
+    }
+  };
+}
+
+export function resultFilteredMapClass<K, T, E extends Error>() {
+  return filteredReadonlyMap<K, Either<E, T>, T>((result) =>
+    result.isRight() ? result.value : undefined,
+  );
+}

--- a/src/utils/strings.ts
+++ b/src/utils/strings.ts
@@ -1,7 +1,9 @@
-export function firstUppercase(str: string): string {
-  return str.slice(0, 1).toUpperCase() + str.slice(1);
+/** Capitalize the first character of a string. */
+export function capitalize(s: string): string {
+  return s.charAt(0).toUpperCase() + s.slice(1);
 }
 
+/** Capitalize the first letter of every word. */
 export function titleCase(str: string): string {
   return str.replaceAll(/\b(?<!')(\w)/g, (_match, ch) => ch.toUpperCase());
 }


### PR DESCRIPTION
`Index` now emits a `changed` event when an entry is added, deleted, or updated. The track/clock blocks are reimplemented on top of this, so they render reliably as soon as the file is indexed.

Fixes #117