### PR TITLE
Improve entity generation

### DIFF
--- a/src/entity/command.ts
+++ b/src/entity/command.ts
@@ -1,7 +1,7 @@
 import { createOrAppendMechanics } from "mechanics/editor";
 import { createOracleGroup } from "mechanics/node-builders";
 import { NoSuchOracleError } from "model/errors";
-import { App, Editor } from "obsidian";
+import { App, Editor, Notice } from "obsidian";
 import IronVaultPlugin from "../index";
 import { Oracle, OracleRollableRow, RollContext } from "../model/oracle";
 import { Roll, RollWrapper } from "../model/rolls";
@@ -112,7 +112,13 @@ export async function generateEntityCommand(
     entityDesc = selectedEntityDescriptor;
   }
 
-  const entity = await generateEntity(plugin, entityDesc);
+  let entity: EntityResults<EntitySpec>;
+  try {
+    entity = await generateEntity(plugin, entityDesc);
+  } catch (e) {
+    new Notice(String(e));
+    throw e;
+  }
 
   createOrAppendMechanics(editor, [
     createOracleGroup(

--- a/src/entity/command.ts
+++ b/src/entity/command.ts
@@ -5,14 +5,14 @@ import { Oracle, OracleRollableRow, RollContext } from "../model/oracle";
 import { Roll, RollWrapper } from "../model/rolls";
 import { OracleRoller } from "../oracles/roller";
 import { CustomSuggestModal } from "../utils/suggest";
+import { EntityModal } from "./modal";
 import {
-  AttributeMechanism,
+  ENTITIES,
   EntityAttributeFieldSpec,
   EntityDescriptor,
-  EntityModal,
   EntityResults,
   EntitySpec,
-} from "./modal";
+} from "./specs";
 
 type OraclePromptOption =
   | { action: "pick"; row: OracleRollableRow }
@@ -90,133 +90,6 @@ export async function generateEntity(
     initialEntity,
   });
 }
-
-const ENTITIES: Record<string, EntityDescriptor<EntitySpec>> = {
-  character: {
-    label: "Character",
-    nameGen: (ent) =>
-      `${ent.givenName[0]?.simpleResult}${ent.callSign.length > 0 ? ' "' + ent.callSign[0].simpleResult + '"' : ""} ${ent.familyName[0]?.simpleResult}`,
-    spec: {
-      givenName: {
-        id: "starforged/oracles/characters/name/given",
-        firstLook: true,
-      },
-      callSign: {
-        id: "starforged/oracles/characters/name/callsign",
-        firstLook: true,
-      },
-      familyName: {
-        id: "starforged/oracles/characters/name/family_name",
-        firstLook: true,
-      },
-      firstLook: {
-        id: "starforged/oracles/characters/first_look",
-        firstLook: true,
-      },
-      initialDisposition: {
-        id: "starforged/oracles/characters/initial_disposition",
-        firstLook: true,
-      },
-      role: {
-        id: "starforged/oracles/characters/role",
-        firstLook: false,
-      },
-      goal: {
-        id: "starforged/oracles/characters/goal",
-        firstLook: false,
-      },
-      revealedAspect: {
-        id: "starforged/oracles/characters/revealed_aspect",
-        firstLook: false,
-      },
-    },
-  },
-  faction: {
-    label: "Faction",
-    nameGen: (ent) => ent.name[0]?.simpleResult,
-    spec: {
-      name: {
-        id: "starforged/oracles/factions/name/template",
-        firstLook: true,
-      },
-    },
-  },
-
-  creature: {
-    label: "Creature",
-    nameGen: (_ent) => "TBD",
-    spec: {
-      environment: {
-        id: "starforged/oracles/creatures/environment",
-        firstLook: true,
-        definesAttribute: {
-          order: 1,
-          mechanism: AttributeMechanism.Snakecase,
-        },
-      },
-      basicForm: {
-        id: "starforged/oracles/creatures/basic_form/{{environment}}",
-        firstLook: true,
-        name: "Basic Form",
-      },
-      scale: {
-        id: "starforged/oracles/creatures/scale",
-        firstLook: true,
-      },
-      firstLook: {
-        id: "starforged/oracles/creatures/first_look",
-        firstLook: true,
-      },
-      encounteredBehavior: {
-        id: "starforged/oracles/creatures/encountered_behavior",
-      },
-      revealedAspect: {
-        id: "starforged/oracles/creatures/revealed_aspect",
-      },
-    },
-  },
-
-  planet: {
-    label: "Planet",
-    nameGen: (ent) => ent.name[0]?.simpleResult,
-    spec: {
-      region: {
-        id: "starforgedsupp/oracles/templates/region",
-        firstLook: true,
-        definesAttribute: {
-          order: 1,
-          mechanism: AttributeMechanism.Snakecase,
-        },
-      },
-      class: {
-        id: "starforged/oracles/planets/class",
-        firstLook: true,
-        definesAttribute: {
-          order: 2,
-          mechanism: AttributeMechanism.ParseId,
-        },
-      },
-      name: {
-        id: "starforged/oracles/planets/{{class}}/name",
-        firstLook: true,
-        name: "Planet Name",
-      },
-      atmosphere: {
-        id: "starforged/oracles/planets/{{class}}/atmosphere",
-        firstLook: true,
-      },
-      observed_from_space: {
-        id: "starforged/oracles/planets/{{class}}/observed_from_space",
-        firstLook: true,
-      },
-      settlements: {
-        id: "starforged/oracles/planets/{{class}}/settlements/{{region}}",
-        firstLook: true,
-        name: "Settlements",
-      },
-    },
-  },
-};
 
 export async function generateEntityCommand(
   plugin: IronVaultPlugin,

--- a/src/entity/modal.ts
+++ b/src/entity/modal.ts
@@ -57,14 +57,21 @@ export class EntityModal<T extends EntitySpec> extends Modal {
     initialEntity: Partial<EntityResults<T>>;
   }): Promise<EntityResults<T>> {
     return new Promise((onAccept, onCancel) => {
-      new this(
-        app,
-        entityDesc,
-        initialEntity,
-        rollContext,
-        onAccept,
-        onCancel,
-      ).open();
+      let modal;
+      try {
+        modal = new this(
+          app,
+          entityDesc,
+          initialEntity,
+          rollContext,
+          onAccept,
+          onCancel,
+        );
+        modal.open();
+      } catch (e) {
+        onCancel(e);
+        if (modal) modal.close();
+      }
     });
   }
 

--- a/src/entity/modal.ts
+++ b/src/entity/modal.ts
@@ -2,51 +2,15 @@ import { App, Modal, Setting } from "obsidian";
 import { partition } from "utils/partition";
 import { Oracle, RollContext } from "../model/oracle";
 import { RollWrapper } from "../model/rolls";
-
-export type EntityDescriptor<T extends EntitySpec> = {
-  label: string;
-  nameGen?: (ent: EntityResults<T>) => string;
-  spec: T;
-};
-
-export enum AttributeMechanism {
-  /** Snake case the result. (e.g., Creature Environment) */
-  Snakecase = "Snakecase",
-  /** Take the last segment of the id: link (e.g., Planet Class) */
-  ParseId = "parse-id",
-}
-
-export type DefinesAttribute = {
-  order: number;
-  mechanism: AttributeMechanism;
-};
-export type EntitySpec = Record<string, EntityFieldSpec>;
-
-export type EntityBaseFieldSpec = {
-  /** Oracle ID. Can use templates with `{{asdf}}` */
-  id: string;
-
-  /** True if this should be rolled as part of first look. */
-  firstLook?: boolean;
-
-  /** Label to use. If null, will use oracle name. */
-  name?: string;
-};
-export type EntityAttributeFieldSpec = EntityBaseFieldSpec & {
-  definesAttribute: DefinesAttribute;
-};
-
-export type EntityFieldSpec = EntityBaseFieldSpec | EntityAttributeFieldSpec;
-
-export function isEntityAttributeSpec(
-  spec: EntityFieldSpec,
-): spec is EntityAttributeFieldSpec {
-  return (spec as EntityAttributeFieldSpec).definesAttribute != null;
-}
-
-export type EntityResults<T extends EntitySpec> = {
-  [key in keyof T]: RollWrapper[];
-};
+import {
+  AttributeMechanism,
+  EntityAttributeFieldSpec,
+  EntityDescriptor,
+  EntityFieldSpec,
+  EntityResults,
+  EntitySpec,
+  isEntityAttributeSpec,
+} from "./specs";
 
 const SAFE_SNAKECASE_RESULT = /^[a-z0-9\s]+$/i;
 // [Rocky World](id:starforged/collections/oracles/planets/rocky)

--- a/src/entity/specs.ts
+++ b/src/entity/specs.ts
@@ -1,9 +1,13 @@
+import { Datasworn } from "@datasworn/core";
 import { RollWrapper } from "model/rolls";
 
 export type EntityDescriptor<T extends EntitySpec> = {
   label: string;
   nameGen?: (ent: EntityResults<T>) => string;
   spec: T;
+
+  /** Id of oracle collection that this entity applies to. */
+  collectionId?: Datasworn.OracleCollectionId;
 };
 
 export enum AttributeMechanism {
@@ -44,8 +48,12 @@ export function isEntityAttributeSpec(
 export type EntityResults<T extends EntitySpec> = {
   [key in keyof T]: RollWrapper[];
 };
+
+// TODO: these should maybe be indexed just like everything into the DataIndexer so we can
+// pull the appropriate ones for our active rulesets?
 export const ENTITIES: Record<string, EntityDescriptor<EntitySpec>> = {
   character: {
+    collectionId: "starforged/collections/oracles/characters",
     label: "Character",
     nameGen: (ent) =>
       `${ent.givenName[0]?.simpleResult}${ent.callSign.length > 0 ? ' "' + ent.callSign[0].simpleResult + '"' : ""} ${ent.familyName[0]?.simpleResult}`,
@@ -84,8 +92,11 @@ export const ENTITIES: Record<string, EntityDescriptor<EntitySpec>> = {
       },
     },
   },
+
+  // TODO(@cwegrzyn): Faction spec items vary based on the type of faction
   faction: {
     label: "Faction",
+    collectionId: "starforged/collections/oracles/factions",
     nameGen: (ent) => ent.name[0]?.simpleResult,
     spec: {
       name: {
@@ -97,7 +108,9 @@ export const ENTITIES: Record<string, EntityDescriptor<EntitySpec>> = {
 
   creature: {
     label: "Creature",
-    nameGen: (_ent) => "TBD",
+    collectionId: "starforged/collections/oracles/creatures",
+    // TODO(@cwegrzyn): should we generate a name based on other aspects?
+    // nameGen: (_ent) => "TBD",
     spec: {
       environment: {
         id: "starforged/oracles/creatures/environment",
@@ -132,6 +145,7 @@ export const ENTITIES: Record<string, EntityDescriptor<EntitySpec>> = {
   planet: {
     label: "Planet",
     nameGen: (ent) => ent.name[0]?.simpleResult,
+    collectionId: "starforged/collections/oracles/planets",
     spec: {
       region: {
         id: "starforgedsupp/oracles/templates/region",

--- a/src/entity/specs.ts
+++ b/src/entity/specs.ts
@@ -1,0 +1,172 @@
+import { RollWrapper } from "model/rolls";
+
+export type EntityDescriptor<T extends EntitySpec> = {
+  label: string;
+  nameGen?: (ent: EntityResults<T>) => string;
+  spec: T;
+};
+
+export enum AttributeMechanism {
+  /** Snake case the result. (e.g., Creature Environment) */
+  Snakecase = "Snakecase",
+  /** Take the last segment of the id: link (e.g., Planet Class) */
+  ParseId = "parse-id",
+}
+
+export type DefinesAttribute = {
+  order: number;
+  mechanism: AttributeMechanism;
+};
+export type EntitySpec = Record<string, EntityFieldSpec>;
+
+export type EntityBaseFieldSpec = {
+  /** Oracle ID. Can use templates with `{{asdf}}` */
+  id: string;
+
+  /** True if this should be rolled as part of first look. */
+  firstLook?: boolean;
+
+  /** Label to use. If null, will use oracle name. */
+  name?: string;
+};
+export type EntityAttributeFieldSpec = EntityBaseFieldSpec & {
+  definesAttribute: DefinesAttribute;
+};
+
+export type EntityFieldSpec = EntityBaseFieldSpec | EntityAttributeFieldSpec;
+
+export function isEntityAttributeSpec(
+  spec: EntityFieldSpec,
+): spec is EntityAttributeFieldSpec {
+  return (spec as EntityAttributeFieldSpec).definesAttribute != null;
+}
+
+export type EntityResults<T extends EntitySpec> = {
+  [key in keyof T]: RollWrapper[];
+};
+export const ENTITIES: Record<string, EntityDescriptor<EntitySpec>> = {
+  character: {
+    label: "Character",
+    nameGen: (ent) =>
+      `${ent.givenName[0]?.simpleResult}${ent.callSign.length > 0 ? ' "' + ent.callSign[0].simpleResult + '"' : ""} ${ent.familyName[0]?.simpleResult}`,
+    spec: {
+      givenName: {
+        id: "starforged/oracles/characters/name/given",
+        firstLook: true,
+      },
+      callSign: {
+        id: "starforged/oracles/characters/name/callsign",
+        firstLook: true,
+      },
+      familyName: {
+        id: "starforged/oracles/characters/name/family_name",
+        firstLook: true,
+      },
+      firstLook: {
+        id: "starforged/oracles/characters/first_look",
+        firstLook: true,
+      },
+      initialDisposition: {
+        id: "starforged/oracles/characters/initial_disposition",
+        firstLook: true,
+      },
+      role: {
+        id: "starforged/oracles/characters/role",
+        firstLook: false,
+      },
+      goal: {
+        id: "starforged/oracles/characters/goal",
+        firstLook: false,
+      },
+      revealedAspect: {
+        id: "starforged/oracles/characters/revealed_aspect",
+        firstLook: false,
+      },
+    },
+  },
+  faction: {
+    label: "Faction",
+    nameGen: (ent) => ent.name[0]?.simpleResult,
+    spec: {
+      name: {
+        id: "starforged/oracles/factions/name/template",
+        firstLook: true,
+      },
+    },
+  },
+
+  creature: {
+    label: "Creature",
+    nameGen: (_ent) => "TBD",
+    spec: {
+      environment: {
+        id: "starforged/oracles/creatures/environment",
+        firstLook: true,
+        definesAttribute: {
+          order: 1,
+          mechanism: AttributeMechanism.Snakecase,
+        },
+      },
+      basicForm: {
+        id: "starforged/oracles/creatures/basic_form/{{environment}}",
+        firstLook: true,
+        name: "Basic Form",
+      },
+      scale: {
+        id: "starforged/oracles/creatures/scale",
+        firstLook: true,
+      },
+      firstLook: {
+        id: "starforged/oracles/creatures/first_look",
+        firstLook: true,
+      },
+      encounteredBehavior: {
+        id: "starforged/oracles/creatures/encountered_behavior",
+      },
+      revealedAspect: {
+        id: "starforged/oracles/creatures/revealed_aspect",
+      },
+    },
+  },
+
+  planet: {
+    label: "Planet",
+    nameGen: (ent) => ent.name[0]?.simpleResult,
+    spec: {
+      region: {
+        id: "starforgedsupp/oracles/templates/region",
+        firstLook: true,
+        definesAttribute: {
+          order: 1,
+          mechanism: AttributeMechanism.Snakecase,
+        },
+      },
+      class: {
+        id: "starforged/oracles/planets/class",
+        firstLook: true,
+        definesAttribute: {
+          order: 2,
+          mechanism: AttributeMechanism.ParseId,
+        },
+      },
+      name: {
+        id: "starforged/oracles/planets/{{class}}/name",
+        firstLook: true,
+        name: "Planet Name",
+      },
+      atmosphere: {
+        id: "starforged/oracles/planets/{{class}}/atmosphere",
+        firstLook: true,
+      },
+      observed_from_space: {
+        id: "starforged/oracles/planets/{{class}}/observed_from_space",
+        firstLook: true,
+      },
+      settlements: {
+        id: "starforged/oracles/planets/{{class}}/settlements/{{region}}",
+        firstLook: true,
+        name: "Settlements",
+      },
+    },
+  },
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,8 +20,10 @@ import { OracleModal } from "oracles/oracle-modal";
 import { IronVaultPluginSettings } from "settings";
 import registerSidebarBlocks from "sidebar/sidebar-block";
 import { SidebarView, VIEW_TYPE } from "sidebar/sidebar-view";
+import { AssetModal } from "tracks/asset-modal";
 import { ProgressContext } from "tracks/context";
 import { ProgressIndex, ProgressIndexer } from "tracks/indexer";
+import installAssetLinkHandler from "tracks/link-override";
 import registerTrackBlock from "tracks/track-block";
 import { IronVaultAPI } from "./api";
 import { CharacterIndexer, CharacterTracker } from "./character-tracker";
@@ -35,8 +37,6 @@ import { registerOracleBlock } from "./oracles/render";
 import { IronVaultSettingTab } from "./settings/ui";
 import { advanceProgressTrack, createProgressTrack } from "./tracks/commands";
 import { pluginAsset } from "./utils/obsidian";
-import installAssetLinkHandler from "tracks/link-override";
-import { AssetModal } from "tracks/asset-modal";
 
 export default class IronVaultPlugin extends Plugin {
   settings!: IronVaultPluginSettings;
@@ -193,8 +193,8 @@ export default class IronVaultPlugin extends Plugin {
       id: "entity-gen",
       name: "Generate an entity",
       icon: "package-plus",
-      editorCallback: async (editor) => {
-        await generateEntityCommand(this, editor);
+      editorCallback: async (editor, ctx) => {
+        await generateEntityCommand(this, editor, ctx);
       },
     });
 

--- a/src/mechanics/node-builders.ts
+++ b/src/mechanics/node-builders.ts
@@ -61,10 +61,14 @@ export function createClockNode(
   });
 }
 
-export function createOracleNode(roll: RollWrapper, prompt?: string): kdl.Node {
+export function createOracleNode(
+  roll: RollWrapper,
+  prompt?: string,
+  name?: string,
+): kdl.Node {
   return node("oracle", {
     properties: {
-      name: `[${oracleNameWithParents(roll.oracle)}](oracle:${roll.oracle.id})`,
+      name: `[${name ?? oracleNameWithParents(roll.oracle)}](oracle:${roll.oracle.id})`,
       // TODO: this is preposterous
       roll: roll.roll.roll,
       result: roll.ownResult,
@@ -138,6 +142,21 @@ export function generateMechanicsNode(move: MoveDescription): Document {
   ];
   return doc;
 }
+
 function generateMoveLink(move: MoveDescription): string {
   return move.id ? `[${move.name}](move:${move.id})` : move.name;
+}
+
+export function createOracleGroup(
+  name: string,
+  oracles: { name?: string; rolls: RollWrapper[] }[],
+): kdl.Node {
+  return node("oracle-group", {
+    properties: {
+      name,
+    },
+    children: oracles.flatMap(({ name, rolls }) =>
+      rolls.map((roll) => createOracleNode(roll, undefined, name)),
+    ),
+  });
 }


### PR DESCRIPTION
* Use "oracle-group" for entity rendering in the journal
* Add an option to create a new file for an entity-- currently uses hardcoded Handlebars template which creates a table
* Use entity generation as command for rolling an oracle collection in the sidebar. If proper entity generation config exists, use it. If not, create a placeholder one with no first look fields.

Fixes #36
Fixes #83